### PR TITLE
add the app engine support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,5 @@ install:
   - go get github.com/smartystreets/goconvey
   - go get code.google.com/p/go-uuid/uuid
   - go get github.com/kaeuferportal/stack2struct
-  - go get google.golang.org/appengine
+
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,12 @@ matrix:
   allow_failures:
     - go: tip
 install:
- 
+  - go get -v -t -d google.golang.org/appengine/...
   - mkdir sdk
   - curl -o sdk.zip "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-1.9.24.zip"
   - unzip sdk.zip -d sdk
   - go get github.com/smartystreets/goconvey
   - go get code.google.com/p/go-uuid/uuid
   - go get github.com/kaeuferportal/stack2struct
-
+  
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
 install:
   - curl -sSo gae_sdk.zip https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-1.9.24.zip
   - unzip -q gae_sdk.zip
+  - go get -v -t -d google.golang.org/appengine/...
   - go get github.com/smartystreets/goconvey
   - go get code.google.com/p/go-uuid/uuid
   - go get github.com/kaeuferportal/stack2struct

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,6 @@ install:
   - go get github.com/kaeuferportal/stack2struct
   - go get golang.org/x/net/context
   - go get google.golang.org/appengine/urlfetch
+  - go get google.golang.org/appengine
 
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ matrix:
   allow_failures:
     - go: tip
 install:
-  - export FILE=go_appengine_sdk_linux_amd64-$(curl https://appengine.google.com/api/updatecheck | grep release | grep -o '[0-9\.]*').zip
+
+  - export  FILE=$(curl https://storage.googleapis.com/appengine-sdks/ | grep -o 'featured/go_appengine_sdk_linux_amd64-[^\<]*' | head -1)
   - curl -O https://storage.googleapis.com/appengine-sdks/featured/$FILE
   - unzip -q $FILE
 
@@ -23,5 +24,5 @@ install:
   - go get google.golang.org/appengine
 
 script:
-- go test github.com/miko-code/raygun4goGAE/...
-  
+    - ./go_appengine/goapp test ./tests;
+    - ./go_appengine/goapp build ./raygun4goGAE;

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ matrix:
   allow_failures:
     - go: tip
 install:
+  - go get -v -t -d google.golang.org/appengine/...
+  - mkdir sdk
+  - curl -o sdk.zip "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-1.9.24.zip"
+  - unzip sdk.zip -d sdk
   - go get github.com/smartystreets/goconvey
   - go get code.google.com/p/go-uuid/uuid
   - go get github.com/kaeuferportal/stack2struct

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,5 @@ install:
   - go get github.com/smartystreets/goconvey
   - go get code.google.com/p/go-uuid/uuid
   - go get github.com/kaeuferportal/stack2struct
+  - go get golang.org/x/net/context
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,6 @@ install:
   - go get code.google.com/p/go-uuid/uuid
   - go get github.com/kaeuferportal/stack2struct
   - go get golang.org/x/net/context
+  - go get google.golang.org/appengine/urlfetch
+
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,6 @@ install:
   - go get google.golang.org/appengine/urlfetch
   - go get google.golang.org/appengine
 
+script:
+- go test github.com/miko-code/raygun4goGAE/...
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ install:
   - go get code.google.com/p/go-uuid/uuid
   - go get github.com/kaeuferportal/stack2struct
   - go get google.golang.org/appengine
-  - go get appengine/aetest
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,15 @@ matrix:
   allow_failures:
     - go: tip
 install:
-  - curl -sSo gae_sdk.zip https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-1.9.24.zip
-  - unzip -q gae_sdk.zip
-  - go get -v -t -d google.golang.org/appengine/...
+  - export FILE=go_appengine_sdk_linux_amd64-$(curl https://appengine.google.com/api/updatecheck | grep release | grep -o '[0-9\.]*').zip
+  - curl -O https://storage.googleapis.com/appengine-sdks/featured/$FILE
+  - unzip -q $FILE
+
   - go get github.com/smartystreets/goconvey
   - go get code.google.com/p/go-uuid/uuid
   - go get github.com/kaeuferportal/stack2struct
   
   
+script:
+    - ./go_appengine/goapp test ./tests;
+    - ./go_appengine/goapp build ./noughtscrosses;

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,5 @@ install:
   - go get github.com/smartystreets/goconvey
   - go get code.google.com/p/go-uuid/uuid
   - go get github.com/kaeuferportal/stack2struct
+  - go get google.golang.org/appengine
+  -go get  appengine/aetest

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ env:
 matrix:
   allow_failures:
     - go: tip
+install:
+ 
   - mkdir sdk
   - curl -o sdk.zip "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-1.9.24.zip"
   - unzip sdk.zip -d sdk

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ install:
   - go get code.google.com/p/go-uuid/uuid
   - go get github.com/kaeuferportal/stack2struct
   - go get google.golang.org/appengine
-  -go get  appengine/aetest
+  - go get appengine/aetest

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   - unzip -q $FILE
 
   - go get github.com/smartystreets/goconvey
-  - go get code.google.com/p/go-uuid/uuid
+  - go get "github.com/pborman/uuid"
   - go get github.com/kaeuferportal/stack2struct
   - go get golang.org/x/net/context
   - go get google.golang.org/appengine/urlfetch

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,3 @@ install:
   - go get code.google.com/p/go-uuid/uuid
   - go get github.com/kaeuferportal/stack2struct
   
-  
-script:
-    - ./go_appengine/goapp test ./tests;
-    - ./go_appengine/goapp build ./noughtscrosses;

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ env:
 matrix:
   allow_failures:
     - go: tip
-install:
-  - go get -v -t -d google.golang.org/appengine/...
   - mkdir sdk
   - curl -o sdk.zip "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-1.9.24.zip"
   - unzip sdk.zip -d sdk

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,8 @@ matrix:
   allow_failures:
     - go: tip
 install:
-  - go get -v -t -d google.golang.org/appengine/...
-  - mkdir sdk
-  - curl -o sdk.zip "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-1.9.24.zip"
-  - unzip sdk.zip -d sdk
+  - curl -sSo gae_sdk.zip https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-1.9.24.zip
+  - unzip -q gae_sdk.zip
   - go get github.com/smartystreets/goconvey
   - go get code.google.com/p/go-uuid/uuid
   - go get github.com/kaeuferportal/stack2struct

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Beko Käuferportal GmbH
+Copyright (c) 2015 Miki haiat
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
-# raygun4go
-[![Build Status](https://travis-ci.org/MindscapeHQ/raygun4go.svg?branch=master)](https://travis-ci.org/MindscapeHQ/raygun4go)
+# raygun4goGAE
+[![Build Status](https://travis-ci.org/miko-code/raygun4goGAE.svg?branch=master)](https://travis-ci.org/miko-code/raygun4goGAE)
 [![Build status](https://ci.appveyor.com/api/projects/status/9pqk769jaxfxp0bb/branch/master?svg=true)](https://ci.appveyor.com/project/kaeuferportal-oss/raygun4go/branch/master)
-[![Coverage](http://gocover.io/_badge/github.com/MindscapeHQ/raygun4go)](http://gocover.io/github.com/MindscapeHQ/raygun4go)
-[![GoDoc](https://godoc.org/github.com/MindscapeHQ/raygun4go?status.svg)](http://godoc.org/github.com/MindscapeHQ/raygun4go)
-[![GoReportcard](http://goreportcard.com/badge/MindscapeHQ/raygun4go)](http://goreportcard.com/report/MindscapeHQ/raygun4go)
+[![Coverage](http://gocover.io/_badge/github.com/miko-code/raygun4goGAE)](http://gocover.io/github.com/miko-code/raygun4goGAE)
+[![GoDoc](https://godoc.org/github.com/miko-code/raygun4goGAE?status.svg)](http://godoc.org/github.com/miko-code/raygun4goGAE)
+[![GoReportcard](http://goreportcard.com/badge/miko-code/raygun4goGAE)](http://goreportcard.com/report/miko-code/raygun4goGAE)
+
 
 raygun4go adds Raygun-based error handling to your golang code. It catches all
 occuring errors, extracts as much information as possible and sends the error
@@ -13,7 +14,7 @@ to Raygun via their REST-API.
 
 ### Installation
 ```
-  $ go get github.com/MindscapeHQ/raygun4go
+  $ go get github.com/miko-code/raygun4goGAE
 ```
 
 ### Basic Usage
@@ -23,13 +24,21 @@ in a context as global as possible. In webservers, this will probably be your
 request handling method, in all other programs it should be your main-method.
 Having found the right spot, just add the following example code:
 
+
 ```
+//generate new appengine context
+ctx := appengine.NewContext(r)
+
 raygun, err := raygun4go.New("appName", "apiKey")
 if err != nil {
   log.Println("Unable to create Raygun client:", err.Error())
 }
 raygun.Silent(true)
-defer raygun.HandleError()
+defer raygun.HandleError(ctx)
+
+raygun.CreateError("this is error", ctx)
+
+
 ```
 
 where ``appName`` is the name of your app and ``apiKey`` is your
@@ -57,7 +66,7 @@ Method                    | Description
 ## Bugs and feature requests
 
 Have a bug or a feature request? Please first check the list of
-[issues](https://github.com/MindscapeHQ/raygun4go/issues).
+[issues](https://github.com/miko-code/raygun4goGAE/issues).
 
 If your problem or idea is not addressed yet, [please open a new
-issue](https://github.com/MindscapeHQ/raygun4go/issues/new).
+issue](https://github.com/miko-code/raygun4goGAE/issues/new).

--- a/raygun4go.go
+++ b/raygun4go.go
@@ -39,14 +39,15 @@ package raygun4go
 
 import (
 	"bytes"
-	"code.google.com/p/go-uuid/uuid"
 	"encoding/json"
 	"errors"
 	"fmt"
-	gcontext "golang.org/x/net/context" //google context
-	"google.golang.org/appengine/urlfetch"
 	"log"
 	"net/http"
+
+	"code.google.com/p/go-uuid/uuid"
+	gcontext "golang.org/x/net/context" //google context
+	"google.golang.org/appengine/urlfetch"
 )
 
 // Client is the struct holding your Raygun configuration and context
@@ -138,7 +139,7 @@ func (c *Client) User(u string) *Client {
 // to handle all panics inside the calling function and all calls made from it.
 // Be sure to call .this in your main function or (if it is webserver) in your
 // request handler as soon as possible.
-func (c *Client) HandleError() {
+func (c *Client) HandleError(ctx gcontext.Context) {
 	if e := recover(); e != nil {
 		err, ok := e.(error)
 		if !ok {
@@ -146,7 +147,8 @@ func (c *Client) HandleError() {
 		}
 		log.Println("Recovering from:", err.Error())
 		post := c.createPost(err, currentStack())
-		c.submit(post)
+
+		c.submitAppEngine(post, ctx)
 	}
 }
 

--- a/raygun4go.go
+++ b/raygun4go.go
@@ -45,7 +45,7 @@ import (
 	"log"
 	"net/http"
 
-	"code.google.com/p/go-uuid/uuid"
+	"github.com/pborman/uuid"
 	gcontext "golang.org/x/net/context" //google context
 	"google.golang.org/appengine/urlfetch"
 )

--- a/raygun4go_test.go
+++ b/raygun4go_test.go
@@ -1,12 +1,12 @@
 package raygun4go
 
 import (
-	"code.google.com/p/go-uuid/uuid"
 	"fmt"
+	"github.com/pborman/uuid"
 
-	"appengine/aetest"
 	. "github.com/smartystreets/goconvey/convey"
 	"google.golang.org/appengine"
+	"google.golang.org/appengine/aetest"
 	"net/http"
 	"net/http/httptest"
 	"net/url"

--- a/raygun4go_test.go
+++ b/raygun4go_test.go
@@ -1,13 +1,13 @@
 package raygun4go
 
 import (
+	"appengine/aetest"
+	"code.google.com/p/go-uuid/uuid"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
-
-	"code.google.com/p/go-uuid/uuid"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -92,6 +92,23 @@ func TestClient(t *testing.T) {
 			c.Silent(false)
 			c.apiKey = "key"
 			c.CreateError("Test: See if this works with Raygun")
+
+		})
+
+		Convey("#CreateErrorAppEngine", func() {
+			ctx, err := aetest.NewContext(nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer ctx.Close()
+			ts := raygunEndpointStub()
+			defer ts.Close()
+			raygunEndpoint = ts.URL
+			c, _ := New("app", "key")
+			c.Silent(false)
+			c.apiKey = "key"
+			c.CreateError("Test: See if this works with Raygun App Engine", ctx)
+
 		})
 	})
 }


### PR DESCRIPTION
Hey ,
As you can see in this [therd](https://raygun.io/forums/thread/23723)  raygun doesn't  work on app engine becouse you cant use http.clinet insted you need to use url fetch.

```
 func (c *Client) CreateError(message string, ctx ...interface{}) 
```

In order  yo use urlfetch  you need to pass it  appengin context .

```
   if len(ctx) > 0 {
    switch v := ctx[0].(type) {
    case gcontext.Context:
        c.submitAppEngine(post, v)
    default:
        c.submit(post)
    }
   } else {
    c.submit(post)

   }
```

If you don't pass anything  it`s still work with the submit method. 

```
func (c *Client) submitAppEngine(post postData, ctx gcontext.Context) 
```

this method will send the data to raygun .

Im not sure that's the best solution   but lets work together to solve this issue 
