### PR TITLE
Ignore authorization header

### DIFF
--- a/request_data.go
+++ b/request_data.go
@@ -119,6 +119,9 @@ func newRequestData(r *http.Request) requestData {
 
 	r.ParseForm()
 
+	headers := arrayMapToStringMap(r.Header)
+	delete(headers, "Authorization")
+
 	return requestData{
 		HostName:    r.Host,
 		URL:         r.URL.String(),
@@ -126,7 +129,7 @@ func newRequestData(r *http.Request) requestData {
 		IPAddress:   r.RemoteAddr,
 		QueryString: arrayMapToStringMap(r.URL.Query()),
 		Form:        arrayMapToStringMap(r.PostForm),
-		Headers:     arrayMapToStringMap(r.Header),
+		Headers:     headers,
 	}
 }
 

--- a/request_data_test.go
+++ b/request_data_test.go
@@ -57,8 +57,9 @@ func TestRequestData(t *testing.T) {
 
 		Convey("Headers", func() {
 			r.Header = map[string][]string{
-				"foo":  {"bar"},
-				"fizz": {"buzz"},
+				"foo":           {"bar"},
+				"Authorization": {"Bearer usersecret"},
+				"fizz":          {"buzz"},
 			}
 			expected := map[string]string{
 				"foo":  "bar",


### PR DESCRIPTION
The headers are currently sent in their entirety. This avoids sending Authorization.

There may be other headers that users may want hidden, so this could probably be expanded to a user-configurable set, but it seems unlikely that Authorization should ever be sent.
