### PR TITLE
Correct data sent from non-UTC machines

### DIFF
--- a/request_data.go
+++ b/request_data.go
@@ -19,7 +19,7 @@ type postData struct {
 // stack trace.
 func newPostData(context contextInformation, err error, stack stackTrace) postData {
 	return postData{
-		OccuredOn: time.Now().Format("2006-01-02T15:04:05Z"),
+		OccuredOn: time.Now().UTC().Format("2006-01-02T15:04:05Z"),
 		Details:   newDetailsData(context, err, stack),
 	}
 }


### PR DESCRIPTION
When running on a machine that is not set to UTC time (eg US Central Daylight GMT-5), the times reported in the Raygun site are off by the offset. For example, in GMT-5, errors reported now show as "5 hours ago."

This PR corrects that.
