### PR TITLE
update repo for uuid package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ matrix:
     - go: tip
 install:
   - go get github.com/smartystreets/goconvey
-  - go get code.google.com/p/go-uuid/uuid
+  - go get github.com/pborman/uuid
   - go get github.com/kaeuferportal/stack2struct

--- a/raygun4go.go
+++ b/raygun4go.go
@@ -45,7 +45,7 @@ import (
 	"log"
 	"net/http"
 
-	"code.google.com/p/go-uuid/uuid"
+	"github.com/pborman/uuid"
 )
 
 // Client is the struct holding your Raygun configuration and context

--- a/raygun4go_test.go
+++ b/raygun4go_test.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"testing"
 
-	"code.google.com/p/go-uuid/uuid"
+	"github.com/pborman/uuid"
 
 	. "github.com/smartystreets/goconvey/convey"
 )


### PR DESCRIPTION
The uuid package currently used by raygun4go is hosted on code.google.com, which is being phased out.

This PR just replaces the import path with the new home for the same package, (the github location is linked to on the project page on code.google.com).

It's working for me. Ta.
