### PR TITLE
Asynchronous calls to raygun, having captured stack traces in the relevant thread

### DIFF
--- a/raygun4go.go
+++ b/raygun4go.go
@@ -182,6 +182,22 @@ func (c *Client) CreateError(message string) error {
 	return c.submit(post)
 }
 
+//Post holds postData (including a stack). This allows for asynchronous reporting to raygun (without losing the stack trace)
+type Post struct {
+	postData postData
+}
+
+//CreatePost is a wrapper to manually post errors to raygun. It also allows to specify the index for stack trace truncation.
+func (c *Client) CreatePost(err error, stackTruncateAt int) Post {
+	post := c.createPost(err, currentStackAt(stackTruncateAt))
+	return Post{postData: post}
+}
+
+//SubmitPost is a wrapper to manually post errors to raygun asynchronously (having previously captured a stack trace on a separate goroutine, using c.CreatePost())
+func (c *Client) SubmitPost(post Post) error {
+	return c.submit(post.postData)
+}
+
 // submit takes care of actually sending the error to Raygun unless the silent
 // option is set.
 func (c *Client) submit(post postData) error {

--- a/request_data.go
+++ b/request_data.go
@@ -74,12 +74,16 @@ func newErrorData(err error, s stackTrace) errorData {
 	}
 }
 
-// currentStac returns the current stack. However, it omits the first 3 entries
+// currentStack returns the current stack. However, it omits the first 4 entries
 // to avoid cluttering the trace with raygun4go-specific calls.
 func currentStack() stackTrace {
+	return currentStackAt(4)
+}
+
+func currentStackAt(index int) stackTrace {
 	s := make(stackTrace, 0, 0)
 	stack2struct.Current(&s)
-	return s[3:]
+	return s[index:]
 }
 
 // stackTraceElement is one element of the error's stack trace. It is filled by


### PR DESCRIPTION
The point of this small-ish change, is to allow us to call raygun asynchronously. This avoids execution delays, while still retaining the relevant stack trace. We have been using this branch in production for a couple of months now.
- `CreatePost` and `SubmitPost` are 2 new methods, to be called on separate goroutines. 
- `CreatePost` captures the stack trace into a type `Post` (the stack trace is stored in a private variable, `.postData`). `CreatePost` is quick and can be called inline.
- `SubmitPost` provides an entry point with which to send the `Post.postData`. `SubmitPost` is exposed to internet speed/reliability - `SubmitPost` should be called from a separate goroutine.
- Also, `CreatePost` provides some more control over stack trace truncation. In the example below, `4` represents the usual number of stack frames to truncate. If you wrap this call inside another function, you may want to vary this parameter - e.g. we typically wrap the call two functions deep, so we use the value `6`. 

Here is how you might use it:

```
    // c is a *raygun4go.Client
    post := c.CreatePost(errorToReport, 4) 
    go func() {
            err = c.SubmitPost(post)
            if err != nil {
                    log.Errorf("Error calling raygun: %s", err)
            }   
    }() 
```

Note that I'd normally add in some `defer`...`recover` handling, but I've left that out for sake of simplicity.

Existing usage patterns should not be affected by this change. Cheers
