### PR TITLE
Added support for Google AppEngine

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,15 @@ the error will be sent to Raygun using your API-key.
 
 The client returned by ``New`` has several chainable option-setting methods
 
-Method                    | Description
---------------------------|------------------------------------------------------------
-`Silent(bool)`            | If set to true, this prevents the handler from sending the error to Raygun, printing it instead.
-`Request(*http.Request)`  | Adds the responsible http.Request to the error.
-`Version(string)`         | If your program has a version, you can add it here.
-`Tags([]string)`          | Adds the given tags to the error. These can be used for filtering later.
-`CustomData(interface{})` | Add arbitrary custom data to you error. Will only reach Raygun if it works with `json.Marshal()`.
-`User(string)`            | Add the name of the affected user to the error.
+Method                                 | Description
+---------------------------------------|----------------------------------------------
+`Silent(bool)`                         | If set to true, this prevents the handler from sending the error to Raygun, printing it instead.
+`Request(*http.Request)`               | Adds the responsible http.Request to the error.
+`Version(string)`                      | If your program has a version, you can add it here.
+`Tags([]string)`                       | Adds the given tags to the error. These can be used for filtering later.
+`CustomData(interface{})`              | Add arbitrary custom data to you error. Will only reach Raygun if it works with `json.Marshal()`.
+`User(string)`                         | Add the name of the affected user to the error.
+`AppAppEngineHTTPClient(*http.Client)` | On Google AppEngine pass the urlfetch.Client 
 
 ## Bugs and feature requests
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Method                                 | Description
 `Tags([]string)`                       | Adds the given tags to the error. These can be used for filtering later.
 `CustomData(interface{})`              | Add arbitrary custom data to you error. Will only reach Raygun if it works with `json.Marshal()`.
 `User(string)`                         | Add the name of the affected user to the error.
-`AppAppEngineHTTPClient(*http.Client)` | On Google AppEngine pass the urlfetch.Client 
+`AppEngineHTTPClient(*http.Client)`    | On Google AppEngine pass the urlfetch.Client 
 
 ## Bugs and feature requests
 

--- a/raygun4go.go
+++ b/raygun4go.go
@@ -51,11 +51,12 @@ import (
 // Client is the struct holding your Raygun configuration and context
 // information that is needed if an error occurs.
 type Client struct {
-	appName     string             // the name of the app
-	apiKey      string             // the api key for your raygun app
-	context     contextInformation // optional context information
-	silent      bool               // if true, the error is printed instead of sent to Raygun
-	logToStdOut bool
+	appName             string             // the name of the app
+	apiKey              string             // the api key for your raygun app
+	context             contextInformation // optional context information
+	silent              bool               // if true, the error is printed instead of sent to Raygun
+	logToStdOut         bool
+	appEngineHTTPClient *http.Client // when running on GAE use the urlfetch http client
 }
 
 // contextInformation holds optional information on the context the error
@@ -86,7 +87,7 @@ func New(appName, apiKey string) (c *Client, err error) {
 	if appName == "" || apiKey == "" {
 		return nil, errors.New("appName and apiKey are required")
 	}
-	c = &Client{appName, apiKey, context, false, false}
+	c = &Client{appName, apiKey, context, false, false, nil}
 	return c, nil
 }
 
@@ -136,6 +137,12 @@ func (c *Client) CustomData(data interface{}) *Client {
 // context.
 func (c *Client) User(u string) *Client {
 	c.context.User = u
+	return c
+}
+
+// AppEngineHTTPClient enables overiding the http.client with Google App Engine http.client using urlfetch
+func (c *Client) AppEngineHTTPClient(client *http.Client) *Client {
+	c.appEngineHTTPClient = client
 	return c
 }
 
@@ -203,7 +210,13 @@ func (c *Client) submit(post postData) error {
 		return errors.New(errMsg)
 	}
 	r.Header.Add("X-ApiKey", c.apiKey)
-	httpClient := http.Client{}
+
+	var httpClient *http.Client
+	if c.appEngineHTTPClient == nil {
+		httpClient = &http.Client{}
+	} else {
+		httpClient = c.appEngineHTTPClient
+	}
 	resp, err := httpClient.Do(r)
 
 	defer resp.Body.Close()


### PR DESCRIPTION
Added a chainable function `AppEngineHTTPClient` to override the http.client used to post the errors.
On a project running on GAE, you should pass a *http.Client returned from [urlfetch](https://godoc.org/google.golang.org/appengine/urlfetch#Client).

`raygun, err := raygun4go.New("appName", "apiKey")`
`if err != nil {`
`log.Println("Unable to create Raygun client:", err.Error())`
`}`
`client := urlfetch.Client(c)`
`raygun.AppEngineHTTPClient(client)`
