### PR TITLE
Fix details.client JSON

### DIFF
--- a/request_data.go
+++ b/request_data.go
@@ -132,7 +132,7 @@ func newRequestData(r *http.Request) requestData {
 
 // clientData is the struct holding information on this client.
 type clientData struct {
-	Name      string `json:"identifier"`
+	Name      string `json:"name"`
 	Version   string `json:"version"`
 	ClientURL string `json:"clientUrl"`
 }


### PR DESCRIPTION
Client name now appears under the JSON property "name" rather than "identity"