### PR TITLE
feat: enable stacktrace overrides

### DIFF
--- a/request_data.go
+++ b/request_data.go
@@ -98,6 +98,10 @@ func (s *StackTrace) AddEntry(lineNumber int, packageName, fileName, methodName 
 	*s = append(*s, StackTraceElement{lineNumber, packageName, fileName, methodName})
 }
 
+type StackTraceReader interface {
+	GetStackTrace() StackTrace
+}
+
 // requestData holds all information on the request from the context
 type RequestData struct {
 	HostName    string            `json:"hostName"`


### PR DESCRIPTION
## Motivation
We use a custom Docker container that reports its stack trace back to our main service if the container exits with an error.
We want to be able to report this stacktrace rather than the stacktrace from the main service which is irrelevant in our context.

## Notes for the reviewer
This PR adds a custom `StackTraceReader` interface to override error stack traces. 
Alternatively, we can use context to override the stacktrace. 
However, this integrates better because we track reportable errors based on the interface implementation.